### PR TITLE
Add Prefix Args Flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ The script file is most stable for -i and -o flags. Other files may bring unwant
 | -sc, --status-codes | This specifies if we can add type support for response of the types provided. Default value is 200[comma separated] |
 | -ft, --force-text   | This specifies if we need to parse text content in postman request or not. Default value is false                   |
 | -te, --throw-error  | This specifies if the program should throw an error                                                                 |
+| -p, --prefix        | This specifies if the output files need prefix                                                                      |
 
 You can use these arguments when running the script or program to provide additional options or information.
 


### PR DESCRIPTION
👋 Greetings, development team!

I'd like to introduce this PR which aims to add a command-line argument flag to provide flexibility to the package users in customizing file and interface names according to their project needs. With the optional prefix option (-p/--prefix), users can avoid major disruptions in their project structure when upgrading or downgrading package versions. By default, if the -p/--prefix flag is not specified, the prefix value will be "" or without prefix.

Previously, in the previous version, there was a default prefix "I" which was removed in the latest update. The purpose of adding this prefix option is to allow users to maintain consistency in their package usage without depending on the developer's decision regarding the removed default prefix. I believe that adding this feature will provide significant value to package users and help enhance the overall user experience.

Thank you for your attention, and I hope this PR will be well-received by the development team.

